### PR TITLE
Prevent array recursion

### DIFF
--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -268,6 +268,7 @@ if (!function_exists('phpseclib_safe_serialize')) {
      * PHP 5.3 will emit a warning.
      *
      * @param mixed $arr
+     * @param string $arr_name Name of the variable to be serialized
      * @param array $refs optional
      * @access public
      */

--- a/phpseclib/Crypt/Random.php
+++ b/phpseclib/Crypt/Random.php
@@ -148,13 +148,13 @@ if (!function_exists('crypt_random_string')) {
             session_start();
 
             $v = $seed = $_SESSION['seed'] = pack('H*', sha1(
-                phpseclib_safe_serialize($_SERVER) .
-                phpseclib_safe_serialize($_POST) .
-                phpseclib_safe_serialize($_GET) .
-                phpseclib_safe_serialize($_COOKIE) .
-                phpseclib_safe_serialize($GLOBALS) .
-                phpseclib_safe_serialize($_SESSION) .
-                phpseclib_safe_serialize($_OLD_SESSION)
+                phpseclib_safe_serialize($_SERVER, '_SERVER') .
+                phpseclib_safe_serialize($_POST, '_POST') .
+                phpseclib_safe_serialize($_GET, '_GET') .
+                phpseclib_safe_serialize($_COOKIE, '_COOKIE') .
+                phpseclib_safe_serialize($GLOBALS, 'GLOBALS') .
+                phpseclib_safe_serialize($_SESSION, '_SESSION') .
+                phpseclib_safe_serialize($_OLD_SESSION, '_OLD_SESSION')
             ));
             if (!isset($_SESSION['count'])) {
                 $_SESSION['count'] = 0;
@@ -271,7 +271,7 @@ if (!function_exists('phpseclib_safe_serialize')) {
      * @param array $refs optional
      * @access public
      */
-    function phpseclib_safe_serialize($arr, $refs = array())
+    function phpseclib_safe_serialize($arr, $arr_name, $refs = array())
     {
         if (is_object($arr)) {
             return '';
@@ -286,13 +286,11 @@ if (!function_exists('phpseclib_safe_serialize')) {
             }
             // without this recursive arrays (eg. $a = []; $a[] = &$a;) would result in an
             // "Allowed memory size of ... bytes exhausted" Fatal error
-            foreach ($refs as $ref) {
-                if ($ref === $arr[$key]) {
-                    continue 2;
-                }
+            if ($arr_name === $key) {
+                continue;
             }
             $refs[] = &$arr[$key];
-            $safearr[$key] = is_array($arr[$key]) ? phpseclib_safe_serialize($arr[$key], $refs) : $arr[$key];
+            $safearr[$key] = is_array($arr[$key]) ? phpseclib_safe_serialize($arr[$key], $key, $refs) : $arr[$key];
         }
         return serialize($safearr);
     }


### PR DESCRIPTION
Refs https://github.com/phpseclib/phpseclib/pull/934/files#r52687924

This uses the array **name** to prevent recursion. It will have "false positives" when an array key is of the same name as the array without being a recursion, but those shouldn't have a big impact on the overall entropy gathering.

Based on an idea from https://stackoverflow.com/questions/255312/how-to-get-a-variable-name-as-a-string-in-php/4034225#4034225. 